### PR TITLE
MacOS and Ubuntu compatibility fixes

### DIFF
--- a/host/beectl-py2.py
+++ b/host/beectl-py2.py
@@ -81,14 +81,15 @@ def main():
     suffix = '.txt'
     if 'ext' in text:
         suffix = '.' + text['ext']
-    f = tempfile.mkstemp(suffix, 'chrome_bee_')
+    f = list(tempfile.mkstemp(suffix, 'chrome_bee_'))
     os.write(f[0], text['text'].encode('utf-8'))
+    os.close(f[0])
     args.append(f[1])
 
     with open(os.devnull, 'w') as devnull:
         subprocess.call(args, stdout = devnull, stderr = devnull)
     st = os.stat(f[1])
-    os.lseek(f[0], 0, os.SEEK_SET)
+    f[0] = os.open(f[1], os.O_RDONLY)
     r = os.read(f[0], st.st_size);
     text = r.decode('utf-8', 'replace')
 

--- a/host/beectl-py3.py
+++ b/host/beectl-py3.py
@@ -78,13 +78,14 @@ def main():
     suffix = '.txt'
     if 'ext' in text:
         suffix = '.' + text['ext']
-    f = tempfile.mkstemp(suffix, 'chrome_bee_')
+    f = list(tempfile.mkstemp(suffix, 'chrome_bee_'))
     os.write(f[0], bytes(text['text'], 'utf-8'))
+    os.close(f[0])
     args.append(f[1])
 
     subprocess.call(args, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
     st = os.stat(f[1])
-    os.lseek(f[0], 0, os.SEEK_SET)
+    f[0] = os.open(f[1], os.O_RDONLY)
     r = os.read(f[0], st.st_size);
     text = r.decode('utf-8', 'replace')
 

--- a/host/patch-manifest.pl
+++ b/host/patch-manifest.pl
@@ -2,14 +2,26 @@
 use warnings;
 use strict;
 use utf8;
-use JSON;
+
+my $json;
+if ( eval "require JSON" ) {
+	$json = JSON->new->utf8->canonical->pretty;
+}
+elsif ( eval "require JSON::PP" ) {
+	$json = JSON::PP->new->utf8->canonical->pretty;
+}
+elsif ( eval "require JSON::XS" ) {
+	$json = JSON::XS->new->utf8->canonical->pretty;
+}
+else {
+	die "Could not import any JSON modules";
+}
 
 my ($infile, $host_path) = @ARGV;
 
 open my $fh, '+<', $infile or die "Failed to open file '$infile'";
 my $input = do { local $/; <$fh> };
 
-my $json = JSON->new;
 my $decoded = $json->decode($input);
 
 $decoded->{'path'} = $host_path;
@@ -21,5 +33,5 @@ foreach my $key (sort keys %{$decoded}) {
 
 truncate $fh, 0;
 seek $fh, 0, 0;
-print $fh $json->canonical->pretty(1)->encode(\%result);
+print $fh $json->encode(\%result);
 close $fh;


### PR DESCRIPTION
host/install.sh - work around `install -D` for MacOS
host/install.sh - try `python3` executable (new Ubuntu installs do not have `python`; `python` is Python 2 on MacOS)
host/patch-manifest.pl - try alternate JSON libraries (MacOS and new Ubuntu installs have `JSON::PP` but not `JSON`)
host/beectl-py*.py - reopen the temporary file after the editor exits. Necessary for vim and MacVim on MacOS.